### PR TITLE
Target name health

### DIFF
--- a/Modules/Handler.lua
+++ b/Modules/Handler.lua
@@ -818,6 +818,8 @@ local function ResetNameplateData(unitframe)
     unitframe.data.level = nil;
 
     unitframe.data.targetName = nil;
+    unitframe.data.targetHealth = nil;
+    unitframe.data.targetHealthMax = nil;
 
     unitframe.data.inCombatWithPlayer = nil;
 
@@ -854,6 +856,8 @@ function Stripes:NAME_PLATE_UNIT_ADDED(unit)
         unitframe.data.creatureType = not unitframe.data.isPlayer and UnitCreatureType(unit) or nil;
         unitframe.data.minus = UnitClassification(unit) == 'minus';
         unitframe.data.targetName = UnitName(unit .. 'target');
+        unitframe.data.targetHealth = UnitHealth(unit .. 'target');
+        unitframe.data.targetHealthMax = UnitHealthMax(unit .. 'target');
 
         if unitframe.data.widgetsOnly then
             unitframe.data.previousType = nil;

--- a/Modules/TargetName.lua
+++ b/Modules/TargetName.lua
@@ -63,7 +63,6 @@ local function TargetChanged(unitframe)
                 targetName = utf8sub(targetName, 0, health_len) .. GREY_COLOR_START .. utf8sub(targetName, health_len + 1) .. "|r";
             end
 
-
             if ROLE_ICON and partyRolesCache[unitframe.data.targetName] then
                 unitframe.TargetName:SetText('» ' .. partyRolesCache[unitframe.data.targetName] .. ' '.. targetName);
             else
@@ -85,9 +84,13 @@ local function OnUpdate(unitframe)
     end
 
     local name = UnitName(unitframe.data.unit .. 'target');
+    local health = UnitHealth(unitframe.data.unit .. 'target');
+    local healthMax = UnitHealthMax(unitframe.data.unit .. 'target');
 
-    if unitframe.data.targetName ~= name then
+    if unitframe.data.targetName ~= name or unitframe.data.targetHealth ~= health then
         unitframe.data.targetName = name;
+        unitframe.data.targetHealth = health;
+        unitframe.data.targetHealthMax = healthMax;
         TargetChanged(unitframe);
     end
 end

--- a/Modules/TargetName.lua
+++ b/Modules/TargetName.lua
@@ -2,10 +2,14 @@ local S, L, O, U, D, E = unpack((select(2, ...)));
 local Module = S:NewNameplateModule('TargetName');
 local Stripes = S:GetNameplateModule('Handler');
 
+-- Lua API
+local strlenutf8 = strlenutf8;
+
 -- WoW API
 local UnitName, UnitExists, UnitGroupRolesAssigned = UnitName, UnitExists, UnitGroupRolesAssigned;
 
 -- Stripes API
+local utf8sub = U.UTF8SUB;
 local GetUnitColor = U.GetUnitColor;
 local ShouldShowName = Stripes.ShouldShowName;
 local IsNameOnlyModeAndFriendly = Stripes.IsNameOnlyModeAndFriendly;
@@ -26,6 +30,8 @@ local ROLE_ICONS = {
     ['HEALER']  = INLINE_HEALER_ICON,
     ['NONE']    = '',
 };
+
+local GREY_COLOR_START = '|cff666666';
 
 local function TargetChanged(unitframe)
     if not unitframe.TargetName then
@@ -52,6 +58,11 @@ local function TargetChanged(unitframe)
             end
         else
             local targetName = GetCachedName(unitframe.data.targetName, true, true, true);
+            if unitframe.data.targetHealth and unitframe.data.targetHealth > 0 and unitframe.data.targetHealthMax and unitframe.data.targetHealthMax > 0 then
+                local health_len = strlenutf8(targetName) * (unitframe.data.targetHealth / unitframe.data.targetHealthMax);
+                targetName = utf8sub(targetName, 0, health_len) .. GREY_COLOR_START .. utf8sub(targetName, health_len + 1) .. "|r";
+            end
+
 
             if ROLE_ICON and partyRolesCache[unitframe.data.targetName] then
                 unitframe.TargetName:SetText('» ' .. partyRolesCache[unitframe.data.targetName] .. ' '.. targetName);


### PR DESCRIPTION
OK, I don't know if this may benefit anyone (except myself).

I usually don't have all nameplates shown, and sometimes I want to know the health of the target of a particular unit.

This little addition shows colored health progress (similar to name-only plates) for the target if `Target name` is enabled.

I only did it for other units (not for the player), but it's your call :-)

If you don't like or don't want this change, it's definitely OK. I love your addon nevertheless :-)

P.S. I don't know if the changes `OnUpdate` function are necessary.